### PR TITLE
[IMP] calendar_event_type_color: secure _compute_color and ensure tes…

### DIFF
--- a/calendar_event_type_color/models/calendar_event.py
+++ b/calendar_event_type_color/models/calendar_event.py
@@ -12,4 +12,5 @@ class CalendarEvent(models.Model):
     @api.depends("categ_ids")
     def _compute_color(self):
         for event in self:
-            event.color = fields.first(event.categ_ids).color
+            first_tag = fields.first(event.categ_ids)
+            event.color = first_tag.color if first_tag else 0

--- a/calendar_event_type_color/tests/__init__.py
+++ b/calendar_event_type_color/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_calendar_event

--- a/calendar_event_type_color/tests/test_calendar_event.py
+++ b/calendar_event_type_color/tests/test_calendar_event.py
@@ -1,0 +1,23 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestCalendarEventColor(TransactionCase):
+
+    def test_color_computation_with_tag(self):
+        tag = self.env['calendar.event.type'].create({
+            'name': 'Blue',
+            'color': 5,
+        })
+        event = self.env['calendar.event'].create({
+            'name': 'Event with Tag',
+            'categ_ids': [(6, 0, [tag.id])],
+        })
+        event._compute_color()
+        self.assertEqual(event.color, 5)
+
+    def test_color_computation_without_tag(self):
+        event = self.env['calendar.event'].create({
+            'name': 'Event without Tag',
+        })
+        event._compute_color()
+        self.assertEqual(event.color, 0)


### PR DESCRIPTION
…t coverage

Hello,

This PR improves the `_compute_color` method on `calendar.event` by safely handling the case where no `categ_ids` are assigned, to avoid potential `AttributeError`.
It includes two unit tests to cover both cases..and pass codecov checks:
- With one tag assigned (should copy the tag color)
- Without any tags (should default to 0)
